### PR TITLE
Add Borderless Windowed Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Its options/command-line arguments are as follows:
 Usage: anipaper <input-file>
   -o Execute only once, without loop (loop enabled by default)
   -w Enable windowed mode (do not set wallpaper)
+  -b Enable borderless windowed mode (do not set wallpaper)
 
 Resolution options:
   -k (Keep) resolution, may appears smaller or bigger than the screen, preserve

--- a/anipaper.c
+++ b/anipaper.c
@@ -109,6 +109,7 @@ static int SDL_EVENT_REFRESH_SCREEN;
 #define CMD_RESOLUTION_SCALE  8
 #define CMD_RESOLUTION_FIT   16
 #define CMD_HW_ACCEL         32
+#define CMD_BORDERLESS       64
 static int cmd_flags = CMD_LOOP | CMD_RESOLUTION_FIT;
 static char device_type[16];
 
@@ -1439,9 +1440,12 @@ static int init_sdl(struct av_decode_params *dp)
 			XCloseDisplay(x11dip);
 
 		/* Create window. */
+		int flags = SDL_WINDOW_SHOWN;
+		if (cmd_flags & CMD_BORDERLESS)
+			flags |= SDL_WINDOW_BORDERLESS;
 		window = SDL_CreateWindow("video",
 			SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
-			width, height, SDL_WINDOW_SHOWN);
+			width, height, flags);
 		if (!window)
 			LOG_GOTO("Unable to create a new SDL Window!\n", out1);
 	}
@@ -1561,7 +1565,8 @@ static void usage(const char *prgname)
 	fprintf(stderr, "Usage: %s <input-file>\n", prgname);
 	fprintf(stderr,
 		"  -o Execute only once, without loop (loop enabled by default)\n"
-		"  -w Enable windowed mode (do not set wallpaper)\n\n"
+		"  -w Enable windowed mode (do not set wallpaper)\n"
+		"  -b Enable borderless windowed mode (do not set wallpaper)\n\n"
 		"Resolution options:\n"
 		"  -k (Keep) resolution, may appears smaller or bigger\n"
 		"     than the screen, preserve aspect ratio\n\n"
@@ -1643,7 +1648,7 @@ static int get_resolution(const char *res, int *w, int *h)
 static char* parse_args(int argc, char **argv)
 {
 	int c; /* Current arg. */
-	while ((c = getopt(argc, argv, "howksfr:d:")) != -1)
+	while ((c = getopt(argc, argv, "howbksfr:d:")) != -1)
 	{
 		switch (c)
 		{
@@ -1655,6 +1660,9 @@ static char* parse_args(int argc, char **argv)
 				break;
 			case 'w':
 				cmd_flags |= CMD_WINDOWED;
+				break;
+			case 'b':
+				cmd_flags |= CMD_WINDOWED | CMD_BORDERLESS;
 				break;
 			case 'k':
 				cmd_flags &= ~(CMD_RESOLUTION_SCALE|CMD_RESOLUTION_FIT);


### PR DESCRIPTION
I'm experimenting with anipaper as a means of enabling animated backgrounds for my project [Flex Launcher](https://github.com/complexlogic/flex-launcher). The method I'm using requires a compositor; in my setup I'm using picom. 

Although anipaper is not compatible with compositors in the wallpaper mode, it can be used in the windowed mode. For my use case, the windowed mode functions close enough to the wallpaper mode. The only problem in the windowed mode is the title bar. I added an option to enable a borderless window so it looks like a wallpaper, but is actually a fullscreen window at the bottom of the stack.

If this is merged, I'll promote anipaper in the setup guide documentation of Flex Launcher so my users can find your project. Thanks for your work on this. Also a great learning material for FFmpeg.

https://user-images.githubusercontent.com/95071366/197448492-fd320497-d2e8-4d81-b25b-1675f6202970.mp4





